### PR TITLE
cleanup error returns and whitelist handling

### DIFF
--- a/src/ble.h
+++ b/src/ble.h
@@ -36,8 +36,7 @@ typedef int (*notification_cb_t)(const char *ble_addr, const char *chrc_uuid,
 				  uint8_t *data, uint16_t len);
 
 int ble_init(void);
-void ble_add_to_allowlist(char *addr_str);
-void ble_remove_from_allowlist(char *addr_str);
+int ble_add_to_allowlist(char *addr_str, bool add);
 void scan_start(bool print_scan);
 void ble_register_notify_callback(notification_cb_t callback);
 int ble_subscribe(char *ble_addr, char *chrc_uuid, uint8_t value_type);
@@ -49,10 +48,10 @@ int gatt_write(char *ble_addr, char *chrc_uuid, uint8_t *data,
 	       uint16_t data_len, bt_gatt_write_func_t cb);
 int gatt_write_without_response(char *ble_addr, char *chrc_uuid, uint8_t *data,
 				uint16_t data_len);
-uint8_t ble_discover(char *ble_addr);
+int ble_discover(char *ble_addr);
 void bt_uuid_get_str(const struct bt_uuid *uuid, char *str, size_t len);
 void bt_to_upper(char *addr, uint8_t addr_len);
-uint8_t disconnect_device_by_addr(char *ble_addr);
+int disconnect_device_by_addr(char *ble_addr);
 void ble_clear_discover_inprogress();
 int device_discovery_send(struct ble_device_conn *conn_ptr);
 int update_shadow(char *ble_address, bool connecting, bool connected);
@@ -60,6 +59,6 @@ struct ble_scanned_dev *get_scanned_device(unsigned int i);
 int get_num_scan_results(void);
 int get_num_scan_names(void);
 void ble_stop_activity(void);
-int setup_gw_shadow(void);
+int setup_gw_shadow(void *modem);
 
 #endif /* _BLE_H_ */

--- a/src/ble_conn_mgr.h
+++ b/src/ble_conn_mgr.h
@@ -69,7 +69,6 @@ int ble_conn_mgr_get_handle_by_uuid(uint16_t *handle, char *uuid,
 				    struct ble_device_conn *conn_ptr);
 void ble_conn_mgr_init();
 int ble_conn_set_connected(char *addr, bool connected);
-int ble_conn_set_disconnected(char *addr);
 int ble_conn_mgr_set_subscribed(uint16_t handle, uint8_t sub_index,
 				struct ble_device_conn *conn_ptr);
 int ble_conn_mgr_remove_subscribed(uint16_t handle,

--- a/src/gateway.c
+++ b/src/gateway.c
@@ -119,7 +119,7 @@ void cloud_data_process(int unused1, int unused2, int unused3)
 			k_free(cloud_data);
 			k_mutex_unlock(&lock);
 		}
-		k_sleep(K_MSEC(1000));
+		k_sleep(K_MSEC(100));
 	}
 }
 


### PR DESCRIPTION
- make all return codes integers using standing error codes in ble.c
- add more error checking
- fix bt_conn_disconnect argument (BT stack change in allowed disconnect reasons)
- eliminate redundant ble_conn_set_disconnected()
- clean up handling of added_to_allowlist flag (fix bug where it got re-added by mistake, when not wanted)
- reduce logging during sending of device discovery
- reduce sleep in cloud_data_process()