### PR TITLE
Feature hide dfu device

### DIFF
--- a/src/ble_conn_mgr.c
+++ b/src/ble_conn_mgr.c
@@ -46,10 +46,12 @@ static void process_connection(int i)
 			dev->added_to_allowlist = true;
 			LOG_INF("Device added to allowlist.");
 		}
-		err = set_shadow_ble_conn(dev->addr, true, false);
-		if (!err) {
-			dev->shadow_updated = true;
-			LOG_INF("Shadow updated.");
+		if (!dev->hidden) {
+			err = set_shadow_ble_conn(dev->addr, true, false);
+			if (!err) {
+				dev->shadow_updated = true;
+				LOG_INF("Shadow updated.");
+			}
 		}
 	}
 
@@ -296,6 +298,19 @@ bool ble_conn_mgr_enabled(const char *addr)
 	}
 
 	return true;
+}
+
+bool ble_conn_mgr_is_desired(const char *addr)
+{
+	struct desired_conn *con;
+
+	if (addr == NULL) {
+		return false;
+	}
+
+	find_desired_connection(addr, &con);
+
+	return (con != NULL) && (con->active);
 }
 
 int ble_conn_mgr_generate_path(struct ble_device_conn *conn_ptr,

--- a/src/ble_conn_mgr.h
+++ b/src/ble_conn_mgr.h
@@ -47,6 +47,7 @@ struct ble_device_conn {
 	bool shadow_updated : 1;
 	bool disconnect : 1;
 	bool dfu_pending : 1;
+	bool hidden : 1;
 };
 
 struct desired_conn {
@@ -86,6 +87,7 @@ int ble_conn_mgr_get_subscribed(uint16_t handle,
 void ble_conn_mgr_update_desired(const char *addr, uint8_t index);
 int ble_conn_mgr_add_desired(const char *addr, bool manual);
 int ble_conn_mgr_rem_desired(const char *addr, bool manual);
+bool ble_conn_mgr_is_desired(const char *addr);
 void ble_conn_mgr_clear_desired(bool all);
 bool ble_conn_mgr_enabled(const char *addr);
 void ble_conn_mgr_update_connections(void);

--- a/src/cli.c
+++ b/src/cli.c
@@ -403,7 +403,7 @@ static void print_conn_info(const struct shell *shell, bool show_path,
 	if (!notify) {
 		shell_print(shell, "   MAC, connected, discovered, shadow"
 				   " updated, denylist status, ctrld by,"
-				   " num UUIDs");
+				   " visible, num UUIDs");
 	}
 	for (i = 0; i < CONFIG_BT_MAX_CONN; i++) {
 		dev = get_connected_device(i);
@@ -411,7 +411,7 @@ static void print_conn_info(const struct shell *shell, bool show_path,
 			continue;
 		}
 		count++;
-		shell_print(shell, "%u. %s, %s, %s, %s, %s, %s, UUIDs:%u",
+		shell_print(shell, "%u. %s, %s, %s, %s, %s, %s, %s, UUIDs:%u",
 			    count,
 			    dev->addr,
 			    dev->connected ? "CONNNECTED" : "disconnected",
@@ -422,6 +422,7 @@ static void print_conn_info(const struct shell *shell, bool show_path,
 			    dev->added_to_allowlist ? "CONN ALLOWED" :
 			    "conn denied",
 			    ble_conn_mgr_enabled(dev->addr) ? "CLOUD" : "local",
+			    !dev->hidden ? "VISIBLE" : "hidden",
 			    (unsigned int)dev->num_pairs
 			   );
 		if (!notify) {

--- a/src/dfu/peripheral_dfu.c
+++ b/src/dfu/peripheral_dfu.c
@@ -488,6 +488,9 @@ int peripheral_dfu_config(const char *addr, int size, const char *version,
 		goto failed;
 	}
 
+	/* special dfu flag -- don't send info to cloud about this dfu device */
+	conn->hidden = true;
+
 	LOG_INF("Waiting for device discovery...");
 	while (!conn->discovered && !conn->encode_discovered) {
 		k_sleep(K_MSEC(100));


### PR DESCRIPTION
Suppress sending of any shadow or data packets related to DFU device,
otherwise the backend adds it to the UI.